### PR TITLE
add variable r in sofa function of doubanrobot.py to fix a tiny bug

### DIFF
--- a/doubanrobot.py
+++ b/doubanrobot.py
@@ -220,7 +220,7 @@ class DoubanRobot:
                         "start" : "0",
                         "submit_btn" : "加上去"
                 }
-                self.session.post("https://www.douban.com/group/topic/" + item[0] + "/add_comment#last?", post_data, cookies=self.session.cookies.get_dict())
+                r = self.session.post("https://www.douban.com/group/topic/" + item[0] + "/add_comment#last?", post_data, cookies=self.session.cookies.get_dict())
                 if r.status_code == 200:
                     logging.info('Okay, send_mail: To %s doumail "%s" successfully!'%(id, content))
         return True


### PR DESCRIPTION
fix this bug 

```

---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
<ipython-input-8-766b8cca18b0> in <module>()
----> 1 app.sofa("CentOS",['aaaa', 'bbbb', 'cccc'])

/doubanrobot/doubanrobot.py in sofa(self, group_id, content)
    222                 }
    223                 self.session.post("https://www.douban.com/group/topic/" + item[0] + "/add_comment#last?", post_data, cookies=self.session.cookies.get_dict())
--> 224                 if r.status_code == 200:
    225                     logging.info('Okay, send_mail: To %s doumail "%s" successfully!'%(id, content))
    226         return True

NameError: global name 'r' is not defined
```